### PR TITLE
Adding options to customise the layout

### DIFF
--- a/config-updater.js
+++ b/config-updater.js
@@ -129,7 +129,10 @@ function copyFile(source, target) {
 }
 
 /**
- * Add options in globals.json to allow customization of layout by the end user
+ * Add options in globals.json to allow
+ *  - customization of the layout by the end user
+ *  - edition of some views title tagline
+ *  - force the redirect to HTTPS
  */
 function updateStep5_Apr2017(targetConfig, sourceConfig, configKey) {
     debug('Performing updateStep5_Apr2017()');
@@ -156,7 +159,7 @@ function updateStep5_Apr2017(targetConfig, sourceConfig, configKey) {
             showBuiltBy: true,
             showBuilds: true
         },
-        sawggerUi: {
+        swaggerUi: {
             menu: {
                 homeLinkText: 'Home',
                 showContactLink: true,

--- a/config-updater.js
+++ b/config-updater.js
@@ -11,7 +11,8 @@ var updateSteps = {
     1: updateStep1_June2016,
     2: updateStep2_June2016,
     3: updateStep3_Oct2016,
-    4: updateStep4_Mar2017
+    4: updateStep4_Mar2017,
+    5: updateStep5_Apr2017
 };
 
 updater.updateConfig = function (staticConfigPath, initialStaticConfigPath, configKey) {
@@ -127,12 +128,73 @@ function copyFile(source, target) {
     fs.writeFileSync(target, fs.readFileSync(source));
 }
 
+/**
+ * Add options in globals.json to allow customization of layout by the end user
+ */
+function updateStep5_Apr2017(targetConfig, sourceConfig, configKey) {
+    debug('Performing updateStep5_Apr2017()');
+
+    var targetGlobals = loadGlobals(targetConfig);
+    targetGlobals.version = 5;
+
+    // Add layouts options
+    targetGlobals.layouts = {
+        defautRootUrl: 'http://wicked.haufe.io',
+        defautRootUrlTarget: '_blank',
+        defautRootUrlText: null,
+        menu: {
+            homeLinkText: 'Home',
+            apisLinkVisibleToGuest: true,
+            applicationsLinkVisibleToGuest: true,
+            contactLinkVisibleToGuest: true,
+            contentLinkVisibleToGuest: true,
+            classForLoginSignupPosition: 'left',
+            showSignupLink: true,
+            loginLinkText: 'Log in'
+        },
+        footer: {
+            showBuiltBy: true,
+            showBuilds: true
+        },
+        sawggerUi: {
+            menu: {
+                homeLinkText: 'Home',
+                showContactLink: true,
+                showContentLink: false
+            }
+        }
+    };
+
+    // Add views options
+    targetGlobals.views = {
+        apis: {
+            showApiIcon: true,
+            titleTagline: 'This is the index of APIs which are available for this API Portal.'
+        },
+        applications: {
+            titleTagline: 'This page displays all your registered applications. \
+It also allows you to register a new application.'
+        },
+        application: {
+            titleTagline: 'This page lets you administer the owners of this application. You can add and remove \
+co-owners of the application. New co-owners must be already be registered in the portal \
+in order to make them co-owners of the application.'
+        }
+    };
+
+    // Add option to force redirection to HTTPS when website is called in HTTP
+    targetGlobals.network.forceRedirectToHttps = false;
+
+    // Save new changes
+    saveGlobals(targetConfig, targetGlobals);
+}
+
 function updateStep4_Mar2017(targetConfig, sourceConfig, configKey) {
     debug('Performing updateStep4_Mar2017()');
 
     var targetGlobals = loadGlobals(targetConfig);
     targetGlobals.version = 4;
-    
+
     // This is a checksum to ensure we are using the same config_key when editing
     // and deploying
     const salt = cryptTools.createRandomId();

--- a/initial-config/static/globals.json
+++ b/initial-config/static/globals.json
@@ -2,6 +2,11 @@
     "version": 1,
     "title": "wicked.haufe.io API Portal",
     "footer": "&copy; 2016 Your Company Ltd.",
+    "layout": {
+        "linkMenuVisibleToGuest": true,
+        "showBuiltByInFooter": true,
+        "showBuildsInFooter": true
+    },
     "api": {
         "headerName": "X-ApiKey"
     },

--- a/initial-config/static/globals.json
+++ b/initial-config/static/globals.json
@@ -2,11 +2,6 @@
     "version": 1,
     "title": "wicked.haufe.io API Portal",
     "footer": "&copy; 2016 Your Company Ltd.",
-    "layout": {
-        "linkMenuVisibleToGuest": true,
-        "showBuiltByInFooter": true,
-        "showBuildsInFooter": true
-    },
     "api": {
         "headerName": "X-ApiKey"
     },


### PR DESCRIPTION
Issue: Haufe-Lexware/wicked.haufe.io#66

Hi,

This first PR add 3 options in the layout namespace to allow a light customization of the main layout.
It should be safe as it keep the same behaviour as before for the layout.

wicked.portal
- Link correction in the layout menu (Hard coded link to main Wicked website)
- Add option to hide API and Applications to guest (not connected users)
- Add option to hide software details in the footer

wicked.portal-env
- Add options in the default globals.json config file