### PR TITLE
[WIP] Fix for PORTAL_STORAGE_PGHOST in helm deployments

### DIFF
--- a/src/config-updater.js
+++ b/src/config-updater.js
@@ -311,12 +311,17 @@ function updateStep14_v1_0_0e(targetConfig, sourceConfig, configKey) {
         // Don't update if there is no localhost env yet
         if (existsEnv(targetConfig, 'localhost')) {
             const localEnv = loadEnv(targetConfig, 'localhost');
-            if (!localEnv.PORTAL_STORAGE_PGPASSWORD) {
-                localEnv.PORTAL_STORAGE_PGPASSWORD = {
+            if (!localEnv.PORTAL_STORAGE_PGHOST) {
+                localEnv.PORTAL_STORAGE_PGHOST = {
                     value: "http://${LOCAL_IP}:5432"
                 };
-                saveEnv(targetConfig, 'localhost', localEnv);
             }
+            if (!localEnv.PORTAL_STORAGE_PGPASSWORD) {
+                localEnv.PORTAL_STORAGE_PGPASSWORD = {
+                    value: "wicked"
+                };
+            }
+            saveEnv(targetConfig, 'localhost', localEnv);
         }
 
     }

--- a/src/config-updater.js
+++ b/src/config-updater.js
@@ -281,14 +281,47 @@ function updateStep14_v1_0_0e(targetConfig, sourceConfig, configKey) {
         const sourceDefaultEnv = loadEnv(sourceConfig, 'default');
         const targetDefaultEnv = loadEnv(targetConfig, 'default');
 
-        if (!targetDefaultEnv.PORTAL_STORAGE_PGHOST)
-            targetDefaultEnv.PORTAL_STORAGE_PGHOST = sourceDefaultEnv.PORTAL_STORAGE_PGHOST;
-        if (!targetDefaultEnv.PORTAL_STORAGE_PGPASSWORD)
-            targetDefaultEnv.PORTAL_STORAGE_PGPASSWORD = sourceDefaultEnv.PORTAL_STORAGE_PGPASSWORD;
 
+        const updateEnv = function (source, target) {
+            let updated = false;
+            if (!targetDefaultEnv.PORTAL_STORAGE_PGHOST){
+                debug('Adding ' + JSON.stringify(source.PORTAL_STORAGE_PGHOST));
+                targetDefaultEnv.PORTAL_STORAGE_PGHOST = sourceDefaultEnv.PORTAL_STORAGE_PGHOST;
+                updated = true;
+            }
+            if (!targetDefaultEnv.PORTAL_STORAGE_PGPASSWORD){
+                debug('Adding ' + JSON.stringify(source.PORTAL_STORAGE_PGPASSWORD));
+                targetDefaultEnv.PORTAL_STORAGE_PGPASSWORD = sourceDefaultEnv.PORTAL_STORAGE_PGPASSWORD;
+                updated = true;
+            }
+            return updated;
+        };
+
+        debug(targetDefaultEnv);
+        updateEnv(sourceDefaultEnv, targetDefaultEnv);
         saveEnv(targetConfig, 'default', targetDefaultEnv);
-    }
+        debug(targetDefaultEnv);
 
+        // Also for k8s env
+        const sourceK8sEnv = loadEnv(sourceConfig, 'k8s');
+        if (existsEnv(targetConfig, 'k8s')) {
+            const targetK8sEnv = loadEnv(targetConfig, 'k8s');
+            if (updateEnv(sourceK8sEnv, targetK8sEnv))
+                saveEnv(targetConfig, 'k8s', targetK8sEnv);
+        }
+        // Don't update if there is no localhost env yet
+        if (existsEnv(targetConfig, 'localhost')) {
+            const localEnv = loadEnv(targetConfig, 'localhost');
+            if (!localEnv.PORTAL_ECHO_URL) {
+                localEnv.PORTAL_ECHO_URL = {
+                    value: "http://${LOCAL_IP}:5432"
+                };
+                saveEnv(targetConfig, 'localhost', localEnv);
+            }
+        }
+
+    }
+⁄
     saveGlobals(targetConfig, targetGlobals);
 }
 

--- a/src/config-updater.js
+++ b/src/config-updater.js
@@ -290,7 +290,6 @@ function updateStep14_v1_0_0e(targetConfig, sourceConfig, configKey) {
                 updated = true;
             }
             if (!targetDefaultEnv.PORTAL_STORAGE_PGPASSWORD){
-                debug('Adding ' + JSON.stringify(source.PORTAL_STORAGE_PGPASSWORD));
                 targetDefaultEnv.PORTAL_STORAGE_PGPASSWORD = sourceDefaultEnv.PORTAL_STORAGE_PGPASSWORD;
                 updated = true;
             }
@@ -312,8 +311,8 @@ function updateStep14_v1_0_0e(targetConfig, sourceConfig, configKey) {
         // Don't update if there is no localhost env yet
         if (existsEnv(targetConfig, 'localhost')) {
             const localEnv = loadEnv(targetConfig, 'localhost');
-            if (!localEnv.PORTAL_ECHO_URL) {
-                localEnv.PORTAL_ECHO_URL = {
+            if (!localEnv.PORTAL_STORAGE_PGPASSWORD) {
+                localEnv.PORTAL_STORAGE_PGPASSWORD = {
                     value: "http://${LOCAL_IP}:5432"
                 };
                 saveEnv(targetConfig, 'localhost', localEnv);


### PR DESCRIPTION
This is just a WIP PR to see if I'm on the right track here.

This is in reference to Issue Haufe-Lexware/wicked.haufe.io#139.  Helm deployments are failing because the `PORTAL_STORAGE_PGHOST` is using the default value of `wicked-database` instead of the k8s hostname.

I noticed that `updateStep12_v1_0_0c` and `updateStep10_v1_0_0a` both had to explicitly update the k8s environment, so I simply followed that process with `updateStep14_v1_0_0e`.

I haven't figured out exactly how I'm going to test that the right values are getting set.  I'd prefer not to go through the whole process of pushing a new image to a personal docker repo to test this out with helm, but I also can't quite envision how to spin up the docker image by itself and pass it all the variables that get set when I run helm.  I thought it might be as simple as setting `envName=k8s` when I spin up the container, but I tried that and it didn't look like what I was expecting. 

At this point, I'd just like to hear feedback that this PR is on the right track.  Feedback very welcome, especially if it's "stop, you're doing it all wrong".